### PR TITLE
Fix case-sensitive extension packaging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
+scripts/**
 .gitignore
 .yarnrc
 vsc-extension-quickstart.md

--- a/package.json
+++ b/package.json
@@ -303,11 +303,13 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "vscode:prepublish": "npm run compile && npm run verify:case-sensitive-imports",
+    "clean": "node ./scripts/clean.js",
+    "compile": "npm run clean && tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile && npm run lint && npm run verify:case-sensitive-imports",
     "lint": "eslint src --ext ts",
+    "verify:case-sensitive-imports": "node ./scripts/verify-case-sensitive-imports.js",
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const outputDirectory = path.resolve(__dirname, '..', 'out');
+fs.rmSync(outputDirectory, {recursive: true, force: true});

--- a/scripts/verify-case-sensitive-imports.js
+++ b/scripts/verify-case-sensitive-imports.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const outputDirectory = path.resolve(process.argv[2] || path.join(__dirname, '..', 'out'));
+const relativeRequire = /require\(\s*['"](\.[^'"]+)['"]\s*\)/g;
+
+function filesUnder(directory) {
+	return fs.readdirSync(directory, {withFileTypes: true}).flatMap(entry => {
+		const child = path.join(directory, entry.name);
+		return entry.isDirectory() ? filesUnder(child) : [child];
+	});
+}
+
+// fs.existsSync() is insufficient on case-insensitive filesystems. Resolve each
+// path component by exact comparison with the directory entry on disk instead.
+function exactFileExists(file) {
+	const parsed = path.parse(file);
+	let resolved = parsed.root;
+	for (const component of path.relative(parsed.root, file).split(path.sep)) {
+		if (!fs.existsSync(resolved)) return false;
+		const exactEntry = fs.readdirSync(resolved).find(entry => entry === component);
+		if (!exactEntry) return false;
+		resolved = path.join(resolved, exactEntry);
+	}
+	return fs.statSync(resolved).isFile();
+}
+
+function exactModuleExists(importer, specifier) {
+	const modulePath = path.resolve(path.dirname(importer), specifier);
+	const candidates = path.extname(modulePath)
+		? [modulePath]
+		: [`${modulePath}.js`, `${modulePath}.json`, path.join(modulePath, 'index.js'), path.join(modulePath, 'index.json')];
+	return candidates.some(exactFileExists);
+}
+
+if (!fs.existsSync(outputDirectory)) {
+	console.error(`Missing compiled output directory: ${outputDirectory}`);
+	process.exitCode = 1;
+} else {
+	const errors = [];
+	for (const file of filesUnder(outputDirectory).filter(file => file.endsWith('.js'))) {
+		const source = fs.readFileSync(file, 'utf8');
+		for (const match of source.matchAll(relativeRequire)) {
+			if (!exactModuleExists(file, match[1])) {
+				errors.push(`${path.relative(outputDirectory, file)} requires ${match[1]}, but no exact-case module exists`);
+			}
+		}
+	}
+
+	if (errors.length) {
+		console.error(errors.join('\n'));
+		process.exitCode = 1;
+	} else {
+		console.log('All compiled relative imports resolve with exact filename casing.');
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		"lib": [
 			"ES2020"
 		],
+		"forceConsistentCasingInFileNames": true,
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true   /* enable all strict type-checking options */


### PR DESCRIPTION
Fixes #45

## Summary
- clean compiled output before every release build so stale, differently-cased artifacts cannot be packaged
- enable TypeScript consistent-filename-casing checks explicitly
- verify that every generated relative `require()` resolves with exact filename casing during prepublish and pretest
- keep build-only verification scripts out of the runtime VSIX

## Root cause
The published v0.5.0 VSIX contained `out/EditorGlue.js`, while `out/extension.js` required `./editorglue`. Case-insensitive local filesystems tolerate that mismatch; Linux, Remote SSH, dev containers, WSL, and Codespaces do not. Not sure how that case-sensitive file got there, but recompiling with fixed and including a test to ensure it matches.

## Verification
- `npm run vscode:prepublish`
- `npm run lint`
- packaged with `@vscode/vsce` and confirmed the VSIX contains exact-case `out/editorglue.js`
- confirmed the verifier rejects the published v0.5.0 VSIX and accepts the repaired package

`npm test` remains unavailable because the existing script references missing `out/test/runTest.js`; this PR does not alter that unrelated test-runner gap.