### PR TITLE
Refresh state IDs after visual edits

### DIFF
--- a/resources/scxmleditor.js
+++ b/resources/scxmleditor.js
@@ -52,6 +52,7 @@ let actionSchema;
 const serializationOptions = {strip:true, indent:'\t', sort:true, cdata:true, tightcdata:true};
 let handleChangeTimer, changeDelayMS = 250;
 function onSCXMLDocChanged() {
+	vscode.postMessage({command:'validIDs', ids:visualEditor.scxmlDoc.ids});
 	// This does not error if the timer has never been set
 	clearTimeout(handleChangeTimer);
 	handleChangeTimer = setTimeout(sendXMLToTextEditor, changeDelayMS);


### PR DESCRIPTION
## Summary

- Send the current state ID list whenever the visual SCXML document changes.
- Make visually added states immediately available as transition targets.
- Keep the same list correct after visual renames and deletions.

## Verification

- `npm run compile`
- `npm run lint`
- `npm run verify:case-sensitive-imports`
- Official `@vscode/vsce` packaging succeeds

Fixes #40