### PR TITLE
Reconnect visual edits after tab switches

### DIFF
--- a/src/editorglue.ts
+++ b/src/editorglue.ts
@@ -209,9 +209,8 @@ export class EditorGlue {
 		const fullRange = this.editor.document.validateRange(new vscode.Range(0, 0, this.editor.document.lineCount, 0));
 		const editorTabCol = this.findEditorTabCol();
 		if (editorTabCol) {
-			window.showTextDocument(this.editor.document, {preserveFocus:true, viewColumn:editorTabCol}).then(() => {
-				this.editor.edit(edit => edit.replace(fullRange, newXML));
-			});
+			const editor = await window.showTextDocument(this.editor.document, {preserveFocus:true, viewColumn:editorTabCol});
+			await editor.edit(edit => edit.replace(fullRange, newXML));
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Use the current `TextEditor` returned by `showTextDocument` when applying visual changes instead of a cached stale editor.
- Avoid editing through the stale editor instance captured before the user switched tabs.
- Preserve the existing document, tab-column, and focus behavior.

## Verification

- `npm run compile`
- `npm run lint`
- `npm run verify:case-sensitive-imports`
- Official `@vscode/vsce` packaging succeeds

Fixes #19