### PR TITLE
Document automatic completion of a single transition anchor

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -23,6 +23,9 @@ should be a human-readable and human-editable XML file.
 ## Transitions
 
 * **`viz:pts="start (wayline+)? end?"`** — route points for the transition line
+  * Either endpoint may be omitted; the editor automatically chooses the missing attachment point.
+    For example, `viz:pts="N10"` fixes the source on its north edge and automatically attaches the
+    other end to the target state.
   * The first and last values (`start` and `end`) describe offsets along an edge of the initial and
     target state; for example, `E20` is a point 20 units down from the top of the right edge, while
     `N0` is a point (nominally) along the of the state at the left edge. Transitions cannot attach


### PR DESCRIPTION
## Summary

- document that either transition endpoint may be omitted
- record the reported `viz:pts=\"N10\"` case as a supported source-anchor-plus-automatic-target route

## Context

Current `main` already synthesizes an automatic target endpoint when only one explicit source anchor is present. This documents that behavior so the stale issue can be closed without introducing a redundant implementation change.

## Verification

- `git diff --check`
- confirmed the current `VisualTransition.anchors` logic appends an automatic target anchor for a single explicit anchor

Fixes #7