### PR TITLE
Fade labels while zooming out

### DIFF
--- a/resources/scxmleditor.css
+++ b/resources/scxmleditor.css
@@ -23,6 +23,9 @@ svg text {
     dominant-baseline:central;
     cursor:default;
 }
+.state text {
+    opacity:var(--state-label-opacity, 1);
+}
 
 .state.parallel .parallel-divider,
 .state.parallel-child .parallel-divider {
@@ -63,7 +66,7 @@ g.transition {
     font-family:Tahoma, 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
     font-size:11px;
     text-anchor:start;
-    opacity:0.5;
+    opacity:var(--transition-label-opacity, 0.5);
 }
 .transition.eventless text {
     display:none;

--- a/resources/visualeditor.js
+++ b/resources/visualeditor.js
@@ -440,6 +440,10 @@ class VisualEditor {
 	}
 
 	onZoomChanged() {
+		const zoomFactor = this.zoomFactor;
+		this.svg.style.setProperty('--transition-label-opacity', Math.max(0, Math.min(0.5, 1 - zoomFactor/2)));
+		this.svg.style.setProperty('--state-label-opacity', Math.max(0, Math.min(1, 2 - zoomFactor/2)));
+
 		// Tell all the child states and transitions
 		this.scxmlDoc.states.forEach(state => state.onZoomChanged());
 		this.scxmlDoc.transitions.forEach(tran => tran.onZoomChanged());


### PR DESCRIPTION
## Summary

- fade transition event labels as the diagram zooms out
- begin fading state names only after transition labels have disappeared
- keep selected labels fully visible through the existing selected-text rule
- apply opacity through SVG CSS variables so newly added states and transitions immediately inherit the current zoom level

## Verification

- `npm run compile`
- `npm run lint`
- `npm run verify:case-sensitive-imports`
- `npx --yes @vscode/vsce package --out /tmp/visual-scxml-editor-issue-10.vsix`
- inspected the packaged CSS and JavaScript for both label-opacity variables

Fixes #10