### PR TITLE
Shrink transition markers when zoomed out

### DIFF
--- a/resources/scxmleditor.html
+++ b/resources/scxmleditor.html
@@ -10,44 +10,44 @@
 </head><body>
 <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 1000' width='100%' height='100%'>
 	<defs>
-		<marker id='source' markerWidth='4' markerHeight='4' refX='2' refY='2'>
+		<marker id='source' viewBox='0 0 4 4' markerWidth='4' markerHeight='4' refX='2' refY='2'>
 			<circle cx='2' cy='2' r='1.5'/>
 		</marker>
-		<marker id='source-conditional' markerWidth='8' markerHeight='8' refX='4' refY='4'>
+		<marker id='source-conditional' viewBox='0 0 8 8' markerWidth='8' markerHeight='8' refX='4' refY='4'>
 			<circle cx='4' cy='4' r='1.5'/>
 		</marker>
-		<marker id='source-conditional-error' markerWidth='8' markerHeight='8' refX='4' refY='4'>
+		<marker id='source-conditional-error' viewBox='0 0 8 8' markerWidth='8' markerHeight='8' refX='4' refY='4'>
 			<circle cx='4' cy='4' r='1.5'/>
 		</marker>
-		<marker id='source-error' markerWidth='4' markerHeight='4' refX='2' refY='2'>
+		<marker id='source-error' viewBox='0 0 4 4' markerWidth='4' markerHeight='4' refX='2' refY='2'>
 			<circle cx='2' cy='2' r='1.5'/>
 		</marker>
 
-		<marker id='target' orient='auto' markerWidth='4' markerHeight='4' refX='2.5' refY='2'>
+		<marker id='target' orient='auto' viewBox='0 0 4 4' markerWidth='4' markerHeight='4' refX='2.5' refY='2'>
 			<polygon points='0,0 0,4 4,2'/>
 		</marker>
-		<marker id='target-error' orient='auto' markerWidth='4' markerHeight='4' refX='2.5' refY='2'>
+		<marker id='target-error' orient='auto' viewBox='0 0 4 4' markerWidth='4' markerHeight='4' refX='2.5' refY='2'>
 			<polygon points='0,0 0,4 4,2'/>
 		</marker>
-		<marker id='target-actions' orient='auto' markerWidth='7' markerHeight='6' refX='5.5' refY='3'>
+		<marker id='target-actions' orient='auto' viewBox='0 0 7 6' markerWidth='7' markerHeight='6' refX='5.5' refY='3'>
 			<path d='M1.5,1 A0.3,0.8,0,0,1,1.5,5'/>
 			<polygon points='3,1 3,5 7,3'/>
 		</marker>
-		<marker id='target-actions-error' orient='auto' markerWidth='7' markerHeight='6' refX='5.5' refY='3'>
+		<marker id='target-actions-error' orient='auto' viewBox='0 0 7 6' markerWidth='7' markerHeight='6' refX='5.5' refY='3'>
 			<path d='M1.5,1 A0.3,0.8,0,0,1,1.5,5'/>
 			<polygon points='3,1 3,5 7,3'/>
 		</marker>
 
-		<marker id='targetless' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
+		<marker id='targetless' viewBox='0 0 7 7' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
 			<circle cx='3.5' cy='3.5' r='1.5'/>
 		</marker>
-		<marker id='targetless-actions' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
+		<marker id='targetless-actions' viewBox='0 0 7 7' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
 			<circle cx='3.5' cy='3.5' r='2.8'/>
 		</marker>
-		<marker id='targetless-error' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
+		<marker id='targetless-error' viewBox='0 0 7 7' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
 			<circle cx='3.5' cy='3.5' r='2.8'/>
 		</marker>
-		<marker id='targetless-actions-error' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
+		<marker id='targetless-actions-error' viewBox='0 0 7 7' markerWidth='7' markerHeight='7' refX='3.5' refY='3.5'>
 			<circle cx='3.5' cy='3.5' r='2.8'/>
 		</marker>
 

--- a/resources/visualeditor.js
+++ b/resources/visualeditor.js
@@ -437,6 +437,12 @@ class VisualEditor {
 		if (w===undefined) w = this.svg.viewBox.baseVal.width;
 		if (h===undefined) h = this.svg.viewBox.baseVal.height;
 		this.svg.setAttribute('viewBox', [x, y, w, h].join(' '));
+
+		const markerScale = Math.min(1, 2/this.zoomFactor);
+		for (const marker of this.svg.querySelectorAll('marker')) {
+			marker.setAttribute('markerWidth', marker.viewBox.baseVal.width * markerScale);
+			marker.setAttribute('markerHeight', marker.viewBox.baseVal.height * markerScale);
+		}
 	}
 
 	onZoomChanged() {


### PR DESCRIPTION
## Summary

- preserve current transition marker sizes through 50% zoom
- shrink marker heads proportionally below that level
- cover every source, target, targetless, action, conditional, and error marker
- retain each marker reference point by scaling its viewport around the existing SVG view box

## Verification

- `npm run compile`
- `npm run lint`
- `npm run verify:case-sensitive-imports`
- `npx --yes @vscode/vsce package --out /tmp/visual-scxml-editor-issue-14.vsix`
- inspected the VSIX: all 12 marker definitions include view boxes and the packaged editor contains the marker scaling logic

Fixes #14