### PR TITLE
Automatically size parallel children when added

### DIFF
--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -168,21 +168,61 @@ export class VisualState extends SCXMLState {
 	}
 
 	addChild(...args) {
+		const existingChildren = this.states;
 		const el = super.addChild(...args);
 		el.initialize(this._vse.editor);
 
 		let parentXYWH = this.xywh;
 		if (parentXYWH) {
-			// TODO: this assumes no other children; when they exist, place this child somewhere better
 			const ed = this._vse.editor;
-			el.xywh = [
-				parentXYWH[0] + ed.gridSize,
-				parentXYWH[1] + VisualState.headerHeight + ed.gridSize,
-				VisualState.defaultLeafWidth,
-				VisualState.defaultLeafHeight
-				,
-			];
-			this.expandToFitChildren();
+			if (this.isParallel) {
+				const [parentX, parentY,, parentH] = parentXYWH;
+				const gridSize = ed.gridSize;
+				const ceilToGrid = value => Math.ceil(value/gridSize) * gridSize;
+				const oldWidths = existingChildren.map(child => child.w);
+				const oldWidthTotal = oldWidths.reduce((sum, width) => sum + width, 0);
+				let parentW = ceilToGrid(parentXYWH[2]);
+				let newWidth, siblingWidths, needsMoreWidth;
+
+				do {
+					newWidth = ceilToGrid(parentW / (existingChildren.length + 1));
+					const siblingUnits = (parentW - newWidth) / gridSize;
+					const exactUnits = oldWidths.map(width => siblingUnits * width / oldWidthTotal);
+					const roundedUnits = exactUnits.map(Math.floor);
+					const unitsLeft = siblingUnits - roundedUnits.reduce((sum, width) => sum + width, 0);
+					exactUnits.map((width, i) => ({i, remainder:width - roundedUnits[i]}))
+						.sort((a,b) => b.remainder - a.remainder || a.i - b.i)
+						.slice(0, unitsLeft)
+						.forEach(({i}) => roundedUnits[i]++);
+					siblingWidths = roundedUnits.map(width => width * gridSize);
+					needsMoreWidth = newWidth < VisualState.minWidth || siblingWidths.some(width => width < VisualState.minWidth);
+					if (needsMoreWidth) {
+						parentW += gridSize;
+					}
+				} while (needsMoreWidth);
+
+				if (parentW!==parentXYWH[2]) {
+					parentXYWH[2] = parentW;
+					this.xywh = parentXYWH;
+				}
+
+				let childX = parentX;
+				const childY = parentY + VisualState.headerHeight;
+				const childH = parentH - VisualState.headerHeight;
+				existingChildren.forEach((child, i) => {
+					child.xywh = [childX, childY, siblingWidths[i], childH];
+					childX += siblingWidths[i];
+				});
+				el.xywh = [childX, childY, newWidth, childH];
+			} else {
+				el.xywh = [
+					parentXYWH[0] + ed.gridSize,
+					parentXYWH[1] + VisualState.headerHeight + ed.gridSize,
+					VisualState.defaultLeafWidth,
+					VisualState.defaultLeafHeight
+				];
+				this.expandToFitChildren();
+			}
 		} else {
 			console.log("FIXME: place and size state added to root");
 			// FIXME: need to place and size state if parent is scxml

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -40,7 +40,7 @@ globalThis.document = {
 const visualDOMSource = fs.readFileSync(new URL('../../resources/visualdom.js', import.meta.url), 'utf8');
 const visualDOMWithStubbedDependency = visualDOMSource.replace(
 	"import { SCXMLDoc, SCXMLState, SCXMLTransition } from 'scxmlDOM';",
-	'class SCXMLDoc {} class SCXMLState {} class SCXMLTransition {}'
+	'class SCXMLDoc {} class SCXMLState { addChild(...args) { return this._addChild(...args); } } class SCXMLTransition {}'
 );
 assert.notEqual(visualDOMWithStubbedDependency, visualDOMSource);
 const {VisualState} = await import(`data:text/javascript;base64,${Buffer.from(visualDOMWithStubbedDependency).toString('base64')}`);
@@ -77,6 +77,40 @@ function drag(state, direction, dx) {
 	handlers.handleDrag(dx, 0, sandbox);
 }
 
+function makeChild(xywh) {
+	let bounds = xywh.slice();
+	return {
+		initialize() {},
+		get w() { return bounds[2]; },
+		get xywh() { return bounds.slice(); },
+		set xywh(value) { bounds = value.slice(); }
+	};
+}
+
+function makeParallelForAdding(parentXYWH, childXYWHs=[]) {
+	let bounds = parentXYWH.slice();
+	const children = childXYWHs.map(makeChild);
+	const newChild = makeChild([0, 0, 120, 40]);
+	const state = Object.create(VisualState.prototype);
+	state.isParallel = true;
+	state._vse = {editor:{gridSize:10}};
+	state._addChild = () => {
+		children.push(newChild);
+		return newChild;
+	};
+	Object.defineProperty(state, 'xywh', {
+		get: () => bounds.slice(),
+		set: value => { bounds = value.slice(); }
+	});
+	Object.defineProperty(state, 'states', {get: () => children.slice()});
+	return {
+		state,
+		children,
+		newChild,
+		getParentXYWH: () => bounds.slice()
+	};
+}
+
 test('an empty parallel resizes horizontally without child errors', () => {
 	const eastResize = makeState();
 	assert.doesNotThrow(() => drag(eastResize, 'e', 40));
@@ -97,4 +131,58 @@ test('a populated parallel keeps its children coupled during resize', () => {
 
 	assert.deepEqual(eastResize.getXYWH(), [10, 20, 140, 80]);
 	assert.equal(children[1].w, 80);
+});
+
+test('the first parallel child fills the area below the header', () => {
+	const fixture = makeParallelForAdding([100, 200, 120, 80]);
+	const added = fixture.state.addChild();
+
+	assert.equal(added, fixture.newChild);
+	assert.deepEqual(fixture.getParentXYWH(), [100, 200, 120, 80]);
+	assert.deepEqual(added.xywh, [100, 230, 120, 50]);
+});
+
+test('a new parallel child is appended while existing widths stay proportional', () => {
+	const fixture = makeParallelForAdding([100, 200, 180, 100], [
+		[100, 230, 120, 70],
+		[220, 230, 60, 70]
+	]);
+	fixture.state.addChild();
+
+	assert.deepEqual(fixture.getParentXYWH(), [100, 200, 180, 100]);
+	assert.deepEqual(fixture.children.map(child => child.xywh), [
+		[100, 230, 80, 70],
+		[180, 230, 40, 70],
+		[220, 230, 60, 70]
+	]);
+});
+
+test('fractional proportional widths are apportioned without gaps', () => {
+	const fixture = makeParallelForAdding([0, 0, 200, 100], [
+		[0, 30, 120, 70],
+		[120, 30, 80, 70]
+	]);
+	fixture.state.addChild();
+
+	assert.deepEqual(fixture.children.map(child => child.xywh), [
+		[0, 30, 80, 70],
+		[80, 30, 50, 70],
+		[130, 30, 70, 70]
+	]);
+});
+
+test('the parallel grows only enough to keep every child at minimum width', () => {
+	const fixture = makeParallelForAdding([0, 0, 120, 100], [
+		[0, 30, 30, 70],
+		[30, 30, 90, 70]
+	]);
+	fixture.state.addChild();
+
+	assert.deepEqual(fixture.getParentXYWH(), [0, 0, 150, 100]);
+	assert.deepEqual(fixture.children.map(child => child.xywh), [
+		[0, 30, 30, 70],
+		[30, 30, 70, 70],
+		[100, 30, 50, 70]
+	]);
+	assert.ok(fixture.children.every(child => child.w >= VisualState.minWidth));
 });


### PR DESCRIPTION
## Summary

- make the first child of a parallel fill the parent below its 30-unit header
- append subsequent children on the right and proportionally redistribute existing widths
- apportion whole grid units without gaps or overlaps when proportional widths are fractional
- minimally widen the parallel until the new child and every resized sibling meet the 30-unit minimum
- retain the existing placement and expand-to-fit behavior for non-parallel parents

## Regression coverage

The unit tests load the real `resources/visualdom.js` implementation and cover:

- first-child sizing with non-zero global parent coordinates
- source-order placement and a nonuniform 2:1 sibling-width ratio
- fractional grid apportionment without gaps
- minimum-width growth caused by a narrow existing sibling
- the pre-existing empty and populated parallel resize behavior

## Verification

- `npm test` — 6 passing
- compile and lint pass through `npm test`
- exact-case import verification passes
- `npx --yes @vscode/vsce package --out /tmp/visual-scxml-editor-issue-57.vsix`
- inspected the packaged `resources/visualdom.js` for the new sizing implementation

Fixes #57