### PR TITLE
Refresh wayline handles after insertion

### DIFF
--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -976,7 +976,7 @@ export class VisualTransition extends SCXMLTransition {
 		const delta = nextValue - prevValue;
 		newAnchor.offset = newAnchor[xy] = prevValue + Math.round(delta/3);
 		this.anchors = anchors;
-		this.placeSelectors();
+		this.createSelectors();
 		// this.reroute();
 	}
 

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -43,7 +43,7 @@ const visualDOMWithStubbedDependency = visualDOMSource.replace(
 	'class SCXMLDoc {} class SCXMLState {} class SCXMLTransition {}'
 );
 assert.notEqual(visualDOMWithStubbedDependency, visualDOMSource);
-const {VisualState} = await import(`data:text/javascript;base64,${Buffer.from(visualDOMWithStubbedDependency).toString('base64')}`);
+const {VisualState, VisualTransition} = await import(`data:text/javascript;base64,${Buffer.from(visualDOMWithStubbedDependency).toString('base64')}`);
 
 function makeState(states=[]) {
 	let xywh = [10, 20, 120, 80];
@@ -97,4 +97,44 @@ test('a populated parallel keeps its children coupled during resize', () => {
 
 	assert.deepEqual(eastResize.getXYWH(), [10, 20, 140, 80]);
 	assert.equal(children[1].w, 80);
+});
+
+function addWayline(anchors, axis) {
+	let currentAnchors = anchors;
+	let selectorsCreated = 0;
+	let selectorsPlaced = 0;
+	const transition = Object.create(VisualTransition.prototype);
+	Object.defineProperty(transition, 'anchors', {
+		get: () => currentAnchors,
+		set: value => { currentAnchors = value; }
+	});
+	transition.createSelectors = () => selectorsCreated++;
+	transition.placeSelectors = () => selectorsPlaced++;
+	transition.addWayline(axis);
+	return {anchors:currentAnchors, selectorsCreated, selectorsPlaced};
+}
+
+test('adding either wayline axis rebuilds selectors for the new handle', () => {
+	for (const [axis, coordinate] of [['X', 'x'], ['Y', 'y']]) {
+		const result = addWayline([
+			{x:0, y:0},
+			{x:90, y:90}
+		], axis);
+
+		assert.equal(result.anchors[1].axis, axis);
+		assert.equal(result.anchors[1][coordinate], 30);
+		assert.equal(result.selectorsCreated, 1);
+		assert.equal(result.selectorsPlaced, 0);
+	}
+});
+
+test('adding a consecutive wayline rebuilds selectors with both handles', () => {
+	const result = addWayline([
+		{x:0, y:0},
+		{axis:'X', offset:30, x:30},
+		{x:90, y:90}
+	], 'X');
+
+	assert.deepEqual(result.anchors.slice(1, 3).map(anchor => anchor.x), [30, 50]);
+	assert.equal(result.selectorsCreated, 1);
 });


### PR DESCRIPTION
## Summary

- rebuild transition selectors immediately after adding a wayline
- show the new guide and handle without requiring deselection and reselection
- cover horizontal, vertical, and consecutive wayline additions

## Why

`addWayline()` updated the transition anchors and then repositioned the existing selectors. Because no selector existed for the newly added anchor, there was nothing new to position. Rebuilding the selector collection creates the missing guide and handle immediately.

## Verification

- npm test — 4 tests passing
- TypeScript compilation, linting, and filename-case verification pass
- packaged and inspected a VSIX containing the fix

Fixes #56