### PR TITLE
Add Set as Initial command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ in a manner that allows the SCXML to still be used in production.
 * `SCXML Editor: Add State` (or `Add Child State`) — Creates new state(s) in the state machine.
   If any state(s) are selected the new states are added as children of them.
   Also available via context menu in the visual editor.
+* `SCXML Editor: Set as Initial` — Marks each eligible selected state as its parent's initial state,
+  replacing any previously marked sibling. Direct children of a `<parallel>` state are ignored, and
+  the command is unavailable when they are the only selected states.
 * `SCXML Editor: Add Transition` — Creates new transition(s) in the state machine, starting at the
   selected state(s). (If no states are selected, uses a quick pick to select a state to start from.)
   Quick picks also let you select the target state, and specify an event name and conditional.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       },
       {
         "category": "SCXML Editor",
+        "command": "visual-scxml-editor.setInitial",
+        "title": "Set as Initial"
+      },
+      {
+        "category": "SCXML Editor",
         "command": "visual-scxml-editor.fitChildren",
         "title": "Expand State to Fit Children"
       },
@@ -137,6 +142,11 @@
           "when":"visual-scxml-editor.stateSelected"
         },
         {
+          "command": "visual-scxml-editor.setInitial",
+          "group": "scxmledit",
+          "when":"visual-scxml-editor.initialCandidateSelected"
+        },
+        {
           "command": "visual-scxml-editor.addHorizontalWayline",
           "group": "scxmledit",
           "when":"visual-scxml-editor.transitionSelected"
@@ -196,6 +206,10 @@
         {
           "command": "visual-scxml-editor.createChildState",
           "when": "visual-scxml-editor.visualEditorActive && visual-scxml-editor.stateSelected"
+        },
+        {
+          "command": "visual-scxml-editor.setInitial",
+          "when": "visual-scxml-editor.visualEditorActive && visual-scxml-editor.initialCandidateSelected"
         },
         {
           "command": "visual-scxml-editor.createTransition",

--- a/resources/scxmleditor.js
+++ b/resources/scxmleditor.js
@@ -115,6 +115,7 @@ window.addEventListener('message', event => {
 		case 'removeVisualization':
 		case 'addVerticalWayline':
 		case 'addHorizontalWayline':
+		case 'setInitial':
 			if (visualEditor[message.command] instanceof Function) {
 				visualEditor[message.command](message);
 			} else {

--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -64,6 +64,14 @@ export class VisualRoot extends SCXMLState {
 		el.initialize(this._vse.editor);
 		return el;
 	}
+
+	updateAttribute(attrNS, attrName) {
+		if (attrName==='initial') {
+			this.states.forEach(s => s.updateLabel());
+			return true;
+		}
+		return false;
+	}
 }
 
 // ****************************************************************************
@@ -306,7 +314,7 @@ export class VisualState extends SCXMLState {
 			break;
 
 			case 'initial':
-				this.states.forEach(s => s.updateLabel);
+				this.states.forEach(s => s.updateLabel());
 				recognized = true;
 			break;
 		}

--- a/resources/visualeditor.js
+++ b/resources/visualeditor.js
@@ -189,6 +189,11 @@ class VisualEditor {
 		for (const t of transitions) t.addWayline(axis);
 	}
 
+	setInitial() {
+		const states = this.selection.filter(o => o.isState && !o.isParallelChild);
+		for (const state of states) state.isInitial = true;
+	}
+
 	makeDraggable(el, obj) {
 		el.addEventListener('mousedown', evt => {
 			if (evt.button) return; // Only drag when button is 0, i.e. left button

--- a/src/editorglue.ts
+++ b/src/editorglue.ts
@@ -38,7 +38,8 @@ export class EditorGlue {
 			stateSelected: false,
 			transitionSelected: false,
 			parentStateSelected: false,
-			parallelSelected: false
+			parallelSelected: false,
+			initialCandidateSelected: false
 		};
 
 		vscode.workspace.onDidCloseTextDocument(textDoc => {
@@ -221,6 +222,7 @@ export class EditorGlue {
 		this.selectedTypes.transitionSelected = false;
 		this.selectedTypes.parentStateSelected = false;
 		this.selectedTypes.parallelSelected = false;
+		this.selectedTypes.initialCandidateSelected = false;
 
 		const editor = this.editor;
 		const doc = editor.document;
@@ -258,6 +260,7 @@ export class EditorGlue {
 				this.selectedTypes.stateSelected = true;
 				if (item.hasChildren) this.selectedTypes.parentStateSelected = true;
 				if (item.name==='parallel') this.selectedTypes.parallelSelected = true;
+				if (item.parentName!=='parallel') this.selectedTypes.initialCandidateSelected = true;
 				const matcher = new RegExp(`<${item.name}[^\\n>]+?id=["']${item.id}["'][^>]+>`, 'm');
 				const match = matcher.exec(scxml);
 				if (match) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,8 @@ export interface SelectionTypes {
 	stateSelected: Boolean,
 	transitionSelected: Boolean,
 	parentStateSelected: Boolean,
-	parallelSelected: Boolean
+	parallelSelected: Boolean,
+	initialCandidateSelected: Boolean
 }
 
 const BlankSCXML = `<?xml version="1.0" encoding="UTF-8"?>
@@ -27,7 +28,8 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {}
 
 const PassAlongCommands = ['createState','createChildState','fitChildren','layoutDiagram','zoomToExtents','zoomTo100','zoomToSelected',
-                           'toggleEventDisplay','deleteSelectionOnly','deleteSelectionAndMore','removeVisualization','addVerticalWayline','addHorizontalWayline'];
+                           'toggleEventDisplay','deleteSelectionOnly','deleteSelectionAndMore','removeVisualization','addVerticalWayline','addHorizontalWayline',
+                           'setInitial'];
 export class SCXMLEditorManager {
 	public glueByURI: Map<vscode.Uri, EditorGlue> = new Map();
 	private _glueWithActiveWebView: EditorGlue | null = null;
@@ -147,7 +149,8 @@ export class SCXMLEditorManager {
 			stateSelected: false,
 			transitionSelected: false,
 			parentStateSelected: false,
-			parallelSelected: false
+			parallelSelected: false,
+			initialCandidateSelected: false
 		};
 		for (const [scope, active] of Object.entries(selectedTypes)) {
 			vscode.commands.executeCommand('setContext', `visual-scxml-editor.${scope}`, active);

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -43,7 +43,15 @@ const visualDOMWithStubbedDependency = visualDOMSource.replace(
 	'class SCXMLDoc {} class SCXMLState { addChild(...args) { return this._addChild(...args); } } class SCXMLTransition {}'
 );
 assert.notEqual(visualDOMWithStubbedDependency, visualDOMSource);
-const {VisualState, VisualTransition} = await import(`data:text/javascript;base64,${Buffer.from(visualDOMWithStubbedDependency).toString('base64')}`);
+const {VisualRoot, VisualState, VisualTransition} = await import(`data:text/javascript;base64,${Buffer.from(visualDOMWithStubbedDependency).toString('base64')}`);
+
+const visualEditorSource = fs.readFileSync(new URL('../../resources/visualeditor.js', import.meta.url), 'utf8');
+const visualEditorWithStubbedDependency = visualEditorSource.replace(
+	"import { VisualDoc, VisualRoot, VisualState, VisualTransition, makeEl } from 'visualDOM';",
+	'class VisualDoc {} class VisualRoot {} class VisualState {} class VisualTransition {} function makeEl() {}'
+);
+assert.notEqual(visualEditorWithStubbedDependency, visualEditorSource);
+const {default:VisualEditor} = await import(`data:text/javascript;base64,${Buffer.from(visualEditorWithStubbedDependency).toString('base64')}`);
 
 function makeState(states=[]) {
 	let xywh = [10, 20, 120, 80];
@@ -259,4 +267,46 @@ test('adding a consecutive wayline rebuilds selectors with both handles', () => 
 
 	assert.deepEqual(result.anchors.slice(1, 3).map(anchor => anchor.x), [30, 50]);
 	assert.equal(result.selectorsCreated, 1);
+});
+
+test('setting selected states as initial replaces sibling choices and skips parallel children', () => {
+	const parent1 = {initial: 'oldSibling'};
+	const parent2 = {initial: null};
+	const parallel = {initial: null};
+	const state = (id, parent, isParallelChild=false) => ({
+		id,
+		parent,
+		isState: true,
+		isParallelChild,
+		set isInitial(makeInitial) {
+			if (makeInitial) this.parent.initial = this.id;
+		}
+	});
+	const editor = Object.create(VisualEditor.prototype);
+	editor.selection = [
+		state('newSibling', parent1),
+		state('nestedInitial', parent2),
+		state('parallelChild', parallel, true),
+		{isTransition: true}
+	];
+
+	editor.setInitial();
+
+	assert.equal(parent1.initial, 'newSibling');
+	assert.equal(parent2.initial, 'nestedInitial');
+	assert.equal(parallel.initial, null);
+});
+
+test('changing an initial attribute refreshes immediate child labels', () => {
+	for (const ParentClass of [VisualRoot, VisualState]) {
+		const refreshes = [];
+		const parent = Object.create(ParentClass.prototype);
+		parent.states = [
+			{updateLabel: () => refreshes.push('first')},
+			{updateLabel: () => refreshes.push('second')}
+		];
+
+		assert.equal(parent.updateAttribute(null, 'initial'), true);
+		assert.deepEqual(refreshes, ['first', 'second']);
+	}
 });


### PR DESCRIPTION
## Summary

- add a plain Set as Initial command to the state context menu
- show the command when at least one selected state is eligible
- exclude states that are immediate children of a parallel while still supporting eligible states in a mixed selection
- replace the parent initial attribute so a previously marked sibling is no longer initial
- refresh root-level and nested state labels immediately after the initial state changes

## Verification

- npm test — 4 tests passing
- TypeScript compilation, linting, and filename-case verification pass
- packaged and inspected /tmp/visual-scxml-editor-issue-46.vsix

Fixes #46