### PR TITLE
Offset overlapping child states when added

### DIFF
--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -215,9 +215,15 @@ export class VisualState extends SCXMLState {
 				});
 				el.xywh = [childX, childY, newWidth, childH];
 			} else {
+				let x = parentXYWH[0] + ed.gridSize;
+				let y = parentXYWH[1] + VisualState.headerHeight + ed.gridSize;
+				while (existingChildren.some(child => child.x===x && child.y===y)) {
+					x += ed.gridSize;
+					y += ed.gridSize;
+				}
 				el.xywh = [
-					parentXYWH[0] + ed.gridSize,
-					parentXYWH[1] + VisualState.headerHeight + ed.gridSize,
+					x,
+					y,
 					VisualState.defaultLeafWidth,
 					VisualState.defaultLeafHeight
 				];

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -187,6 +187,40 @@ test('the parallel grows only enough to keep every child at minimum width', () =
 	assert.ok(fixture.children.every(child => child.w >= VisualState.minWidth));
 });
 
+function addChildWithSiblingPositions(siblingPositions) {
+	let childXYWH;
+	let expansionCount = 0;
+	const child = {
+		initialize() {},
+		set xywh(value) { childXYWH = value; }
+	};
+	const parent = Object.create(VisualState.prototype);
+	parent.isParallel = false;
+	parent.states = siblingPositions.map(([x,y]) => ({x,y}));
+	parent._vse = {editor:{gridSize:10}};
+	parent._addChild = () => child;
+	parent.expandToFitChildren = () => expansionCount++;
+	Object.defineProperty(parent, 'xywh', {get:() => [100, 200, 220, 100]});
+
+	parent.addChild();
+	return {childXYWH, expansionCount};
+}
+
+test('new children of a non-parallel parent use the first unoccupied diagonal grid position', () => {
+	assert.deepEqual(addChildWithSiblingPositions([]), {
+		childXYWH: [110, 240, 120, 40],
+		expansionCount: 1
+	});
+	assert.deepEqual(addChildWithSiblingPositions([
+		[110, 240],
+		[120, 250],
+		[130, 999]
+	]), {
+		childXYWH: [130, 260, 120, 40],
+		expansionCount: 1
+	});
+});
+
 function addWayline(anchors, axis) {
 	let currentAnchors = anchors;
 	let selectorsCreated = 0;


### PR DESCRIPTION
## Summary

- preserve the existing initial placement for children of non-parallel states
- when that exact position is occupied, advance both X and Y by one grid unit until an unoccupied position is found
- leave parallel-parent placement unchanged
- cover the original position and consecutive occupied diagonal positions with a unit test

## Verification

- npm test — 5 tests passing
- TypeScript compilation, linting, and filename-case verification pass
- packaged and inspected /tmp/visual-scxml-editor-offset-overlapping-children.vsix