### PR TITLE
Clear selection before deleting graphics

### DIFF
--- a/resources/visualeditor.js
+++ b/resources/visualeditor.js
@@ -297,13 +297,15 @@ class VisualEditor {
 	}
 
 	deleteSelectionOnly() {
-		for (const o of this.selection) o.delete(true);
+		const selection = this.selection.concat();
 		this.clearSelection();
+		for (const o of selection) o.delete(true);
 	}
 
 	deleteSelectionAndMore() {
-		for (const o of this.selection) o.delete(true, true);
+		const selection = this.selection.concat();
 		this.clearSelection();
+		for (const o of selection) o.delete(true, true);
 	}
 
 	toggleEventDisplay() {

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -310,3 +310,32 @@ test('changing an initial attribute refreshes immediate child labels', () => {
 		assert.deepEqual(refreshes, ['first', 'second']);
 	}
 });
+
+test('deleting a selection clears it before removing graphics', () => {
+	for (const [command, expectedDeleteArgs] of [
+		['deleteSelectionOnly', [true]],
+		['deleteSelectionAndMore', [true, true]]
+	]) {
+		const editor = Object.create(VisualEditor.prototype);
+		let graphicsExist = true;
+		let deleteArgs;
+		const deletedItem = {
+			visuallyDeselect() {
+				assert.equal(graphicsExist, true);
+			},
+			delete(...args) {
+				assert.deepEqual(editor.selection, []);
+				deleteArgs = args;
+				graphicsExist = false;
+			}
+		};
+		const nextItem = {visuallySelect() {}};
+		editor.selection = [deletedItem];
+
+		editor[command]();
+		editor.setSelection([nextItem]);
+
+		assert.deepEqual(deleteArgs, expectedDeleteArgs);
+		assert.deepEqual(editor.selection, [nextItem]);
+	}
+});


### PR DESCRIPTION
## Summary

- snapshot and clear the visual selection before deleting its objects
- avoid trying to deselect a state after its SVG graphics have already been removed
- keep subsequent visual selection working without switching focus to the SCXML text editor
- cover both deletion commands and selection of another item afterward

## Why

The deletion commands removed selected state graphics before calling clearSelection(). Deselecting that deleted state then accessed its missing visual state and threw, leaving the stale deleted object selected.

## Verification

- regression test fails against unmodified main and passes with this fix
- npm test — 12 tests passing
- TypeScript compilation, linting, and filename-case verification pass
- packaged and inspected /tmp/visual-scxml-editor-issue-62.vsix

Fixes #62