### PR TITLE
Ignore malformed transition routing tokens

### DIFF
--- a/resources/scxmleditor.js
+++ b/resources/scxmleditor.js
@@ -4,6 +4,7 @@
 
 import { loadFromString as loadSCXML } from 'scxmlDOM';
 import VisualEditor from 'visualEditor';
+import { parseRoutingPoints } from 'visualDOM';
 import neatXML from 'neatXML';
 
 const NS = 'http://www.w3.org/2005/07/scxml';
@@ -76,7 +77,7 @@ window.addEventListener('message', event => {
 			if (Array.isArray(scxmlDocOrErrors)) {
 				vscode.postMessage({command:'showErrors', errors:scxmlDocOrErrors});
 			} else {
-				vscode.postMessage({command:'clearErrors'});
+				vscode.postMessage({command:'showErrors', errors:routingWarnings(scxmlDocOrErrors, xmlString)});
 				if (visualEditor.scxmlDoc) visualEditor.scxmlDoc.removeEventListener('changed', onSCXMLDocChanged, false);
 				visualEditor.useSCXML(scxmlDocOrErrors);
 				vscode.postMessage({command:'validIDs', ids:scxmlDocOrErrors.ids});
@@ -124,6 +125,31 @@ window.addEventListener('message', event => {
 		break;
 	}
 });
+
+function routingWarnings(scxmlDoc, xmlString) {
+	let searchIndex = 0;
+	return scxmlDoc.transitions.flatMap(transition => {
+		const attr = transition.getAttributeNodeNS(visualNS, 'pts');
+		if (!attr) return [];
+
+		const attrName = attr.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		const matcher = new RegExp(`${attrName}\\s*=\\s*(["'])`, 'g');
+		matcher.lastIndex = searchIndex;
+		const match = matcher.exec(xmlString);
+		const valueIndex = match ? matcher.lastIndex : 0;
+		searchIndex = valueIndex + attr.value.length;
+		const invalid = parseRoutingPoints(attr.value).invalid;
+		if (!invalid.length) return [];
+
+		const precedingText = xmlString.slice(0, valueIndex);
+		return [{
+			line: precedingText.split('\n').length,
+			col: valueIndex - precedingText.lastIndexOf('\n'),
+			severity: 'warning',
+			msg: `Ignored malformed transition routing token${invalid.length===1 ? '' : 's'}: ${invalid.join(', ')}`
+		}];
+	});
+}
 
 function setOptions(sel, values, selectedValue) {
 	sel.options.length = 0;

--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -1236,11 +1236,9 @@ export class VisualTransition extends SCXMLTransition {
 		const pts = this.pts;
 		if (!this.pts) return this.bestAnchors();
 		const source=this.source, target=this.target;
-		let anchors = [], regex = /a|([NSEWXY])\s*(\S+)/g;
-		let match;
-		while (match=regex.exec(pts)) {
-			const [auto, direction, offset] = match;
-			if (auto==='a') anchors.push({auto:true});
+		let anchors = [];
+		for (const {auto, direction, offset} of parseRoutingPoints(pts).points) {
+			if (auto) anchors.push({auto:true});
 			else switch (direction) {
 				case 'X': anchors.push({axis:direction, offset:offset, x:offset*1, horiz:false}); break;
 				case 'Y': anchors.push({axis:direction, offset:offset, y:offset*1, horiz:true }); break;
@@ -1351,6 +1349,22 @@ export class VisualTransition extends SCXMLTransition {
 		else     this.removeAttributeNS(visualNS, 'pts');
 		delete this._anchors;
 	}
+}
+
+// ****************************************************************************
+
+export function parseRoutingPoints(pts='') {
+	const matcher = /(?:^|\s)(a|([NSEWXY])\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?))(?=\s|$)/g;
+	const points = [], invalid = [];
+	let lastIndex = 0, match;
+	while (match=matcher.exec(pts)) {
+		invalid.push(...pts.slice(lastIndex, match.index).trim().split(/\s+/).filter(Boolean));
+		const [, token, direction, offset] = match;
+		points.push(token==='a' ? {auto:true} : {direction, offset:Number(offset)});
+		lastIndex = matcher.lastIndex;
+	}
+	invalid.push(...pts.slice(lastIndex).trim().split(/\s+/).filter(Boolean));
+	return {points, invalid};
 }
 
 // ****************************************************************************

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,10 +106,11 @@ export class SCXMLEditorManager {
 
 	public showErrors(doc: vscode.TextDocument, errors: any[]) {
 		const diags: vscode.Diagnostic[] = errors.map(error => {
+			const warning = error.severity==='warning';
 			return new vscode.Diagnostic(
 				new vscode.Range(error.line-1, error.col-1, error.line-1, error.col),
-				`Error parsing SCXML: ${error.msg}`,
-				vscode.DiagnosticSeverity.Error
+				warning ? error.msg : `Error parsing SCXML: ${error.msg}`,
+				warning ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error
 			);
 		});
 		this.diagnostics.set(doc.uri, diags);

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -43,7 +43,7 @@ const visualDOMWithStubbedDependency = visualDOMSource.replace(
 	'class SCXMLDoc {} class SCXMLState { addChild(...args) { return this._addChild(...args); } } class SCXMLTransition {}'
 );
 assert.notEqual(visualDOMWithStubbedDependency, visualDOMSource);
-const {VisualRoot, VisualState, VisualTransition} = await import(`data:text/javascript;base64,${Buffer.from(visualDOMWithStubbedDependency).toString('base64')}`);
+const {VisualRoot, VisualState, VisualTransition, parseRoutingPoints} = await import(`data:text/javascript;base64,${Buffer.from(visualDOMWithStubbedDependency).toString('base64')}`);
 
 const visualEditorSource = fs.readFileSync(new URL('../../resources/visualeditor.js', import.meta.url), 'utf8');
 const visualEditorWithStubbedDependency = visualEditorSource.replace(
@@ -267,6 +267,36 @@ test('adding a consecutive wayline rebuilds selectors with both handles', () => 
 
 	assert.deepEqual(result.anchors.slice(1, 3).map(anchor => anchor.x), [30, 50]);
 	assert.equal(result.selectorsCreated, 1);
+});
+
+test('malformed routing tokens are ignored without producing invalid paths', () => {
+	const makeState = xywh => {
+		const state = Object.create(VisualState.prototype);
+		Object.defineProperty(state, 'xywh', {get:() => xywh});
+		return state;
+	};
+	for (const [pts, invalid] of [
+		['S X100', ['S']],
+		['X100 Y X200', ['Y']]
+	]) {
+		let path;
+		const transition = Object.create(VisualTransition.prototype);
+		transition.source = makeState([0, 80, 120, 50]);
+		transition.target = makeState([0, 0, 120, 50]);
+		transition._vse = {
+			path: {setAttribute: (_, value) => { path = value; }},
+			catcher: {setAttribute() {}}
+		};
+		Object.defineProperties(transition, {
+			event: {get:() => ''},
+			pts: {get:() => pts},
+			radius: {get:() => 100}
+		});
+
+		assert.deepEqual(parseRoutingPoints(pts).invalid, invalid);
+		transition.reroute();
+		assert.doesNotMatch(path, /NaN|undefined/);
+	}
 });
 
 test('setting selected states as initial replaces sibling choices and skips parallel children', () => {


### PR DESCRIPTION
Fixes #44.

## What changed

- Parse only complete, numeric transition routing tokens.
- Ignore malformed fragments while preserving any valid routing instructions.
- Report ignored tokens as VS Code Problems warnings at the `viz:pts` attribute.
- Cover both malformed examples from the issue and verify they cannot generate paths containing `NaN` or `undefined`.

## Verification

- `npm test` (13 passing tests, plus compile, lint, and case-sensitive import checks)
- Packaged `/tmp/visual-scxml-editor-issue-44.vsix` and inspected the affected webview resources and compiled extension diagnostic code.