### PR TITLE
Fade overflowing state labels

### DIFF
--- a/resources/scxmleditor.css
+++ b/resources/scxmleditor.css
@@ -26,6 +26,9 @@ svg text {
 .state text {
     opacity:var(--state-label-opacity, 1);
 }
+.state text[mask] {
+    text-anchor:start;
+}
 
 .state.parallel .parallel-divider,
 .state.parallel-child .parallel-divider {

--- a/resources/scxmleditor.css
+++ b/resources/scxmleditor.css
@@ -26,6 +26,9 @@ svg text {
 .state text {
     opacity:var(--state-label-opacity, 1);
 }
+.state.parallel > text {
+    opacity:var(--state-label-opacity, 1) !important;
+}
 .state text[mask] {
     text-anchor:start;
 }

--- a/resources/scxmleditor.html
+++ b/resources/scxmleditor.html
@@ -10,6 +10,11 @@
 </head><body>
 <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 1000' width='100%' height='100%'>
 	<defs>
+		<linearGradient id='state-label-fade' x1='0' y1='0' x2='1' y2='0'>
+			<stop offset='0' stop-color='white'/>
+			<stop offset='1' stop-color='white' stop-opacity='0'/>
+		</linearGradient>
+
 		<marker id='source' viewBox='0 0 4 4' markerWidth='4' markerHeight='4' refX='2' refY='2'>
 			<circle cx='2' cy='2' r='1.5'/>
 		</marker>

--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -6,6 +6,7 @@ import { SCXMLDoc, SCXMLState, SCXMLTransition } from 'scxmlDOM';
 const SCXMLNS  = 'http://www.w3.org/2005/07/scxml';
 const SVGNS    = 'http://www.w3.org/2000/svg';
 const visualNS = 'http://phrogz.net/visual-scxml';
+let nextStateLabelMaskId = 0;
 
 export class VisualDoc extends SCXMLDoc {
 	createElementNS(nsURI, name, ...rest) {
@@ -543,36 +544,10 @@ export class VisualState extends SCXMLState {
 			prefix += this.isDeep ? '★ ' : '✪ ';
 		}
 
-		const label = this._vse.label;
 		const id = this.id || '';
-		const availableWidth = Math.max(0, this.w - 2*this.cornerRadius);
-		const fits = text => {
-			label.textContent = text;
-			return label.getComputedTextLength() <= availableWidth;
-		};
-		const fullLabel = `${prefix}${id}${postfix}`;
-		let visibleLabel = fullLabel;
-
-		if (!fits(fullLabel)) {
-			let shortest = 0, longest = id.length;
-			while (shortest < longest) {
-				const length = Math.ceil((shortest + longest) / 2);
-				if (fits(`${prefix}${id.slice(0, length)}…${postfix}`)) shortest = length;
-				else longest = length - 1;
-			}
-
-			visibleLabel = `${prefix}${id.slice(0, shortest)}…${postfix}`;
-			if (!fits(visibleLabel)) {
-				visibleLabel = `${prefix.trimEnd()}…`;
-				if (!fits(visibleLabel)) {
-					visibleLabel = prefix.trimEnd();
-					if (!fits(visibleLabel)) visibleLabel = fits('…') ? '…' : '';
-				}
-			}
-		}
-
-		label.textContent = visibleLabel;
-		makeEl('title', {_dad:label}).textContent = id;
+		this._vse.label.textContent = `${prefix}${id}${postfix}`;
+		makeEl('title', {_dad:this._vse.label}).textContent = id;
+		this.updateLabelPosition();
 	}
 
 	updateColor() {
@@ -585,8 +560,42 @@ export class VisualState extends SCXMLState {
 	updateLabelPosition() {
 		const [,,w,h] = this.xywh;
 		const top = this.states.length>0 ? 15 : h/2;
-		setAttributes(this._vse.label, {x:w/2, y:top});
-		this.updateLabel();
+		const ego = this._vse;
+		const availableWidth = Math.max(0, w - 2*this.cornerRadius);
+		const overflowing = ego.label.getComputedTextLength() >= availableWidth - 1;
+		setAttributes(ego.label, {
+			x: overflowing ? this.cornerRadius : w/2,
+			y: top,
+			'text-anchor': overflowing ? 'start' : 'middle'
+		});
+
+		if (overflowing) {
+			if (!ego.labelMask) {
+				const maskId = `state-label-mask-${++nextStateLabelMaskId}`;
+				ego.labelMask = makeEl('mask', {
+					_dad:ego.main,
+					id:maskId,
+					maskUnits:'userSpaceOnUse',
+					maskContentUnits:'userSpaceOnUse'
+				});
+				ego.labelMaskSolid = makeEl('rect', {_dad:ego.labelMask, fill:'white'});
+				ego.labelMaskFade = makeEl('rect', {_dad:ego.labelMask, fill:'url(#state-label-fade)'});
+				ego.label.setAttribute('mask', `url(#${maskId})`);
+			}
+
+			const fadeWidth = Math.min(15, availableWidth);
+			const solidWidth = availableWidth - fadeWidth;
+			const maskY = top - VisualState.headerHeight/2;
+			setAttributes(ego.labelMask, {x:this.cornerRadius, y:maskY, width:availableWidth, height:VisualState.headerHeight});
+			setAttributes(ego.labelMaskSolid, {x:this.cornerRadius, y:maskY, width:solidWidth, height:VisualState.headerHeight});
+			setAttributes(ego.labelMaskFade, {x:this.cornerRadius+solidWidth, y:maskY, width:fadeWidth, height:VisualState.headerHeight});
+		} else if (ego.labelMask) {
+			ego.label.removeAttribute('mask');
+			ego.labelMask.parentNode.removeChild(ego.labelMask);
+			delete ego.labelMask;
+			delete ego.labelMaskSolid;
+			delete ego.labelMaskFade;
+		}
 	}
 
 	containedWithin(s2) {

--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -565,8 +565,7 @@ export class VisualState extends SCXMLState {
 		const overflowing = ego.label.getComputedTextLength() >= availableWidth - 1;
 		setAttributes(ego.label, {
 			x: overflowing ? this.cornerRadius : w/2,
-			y: top,
-			'text-anchor': overflowing ? 'start' : 'middle'
+			y: top
 		});
 
 		if (overflowing) {

--- a/resources/visualdom.js
+++ b/resources/visualdom.js
@@ -542,7 +542,37 @@ export class VisualState extends SCXMLState {
 		if (this.isHistory) {
 			prefix += this.isDeep ? '★ ' : '✪ ';
 		}
-		this._vse.label.textContent = `${prefix}${this.id}${postfix}`;
+
+		const label = this._vse.label;
+		const id = this.id || '';
+		const availableWidth = Math.max(0, this.w - 2*this.cornerRadius);
+		const fits = text => {
+			label.textContent = text;
+			return label.getComputedTextLength() <= availableWidth;
+		};
+		const fullLabel = `${prefix}${id}${postfix}`;
+		let visibleLabel = fullLabel;
+
+		if (!fits(fullLabel)) {
+			let shortest = 0, longest = id.length;
+			while (shortest < longest) {
+				const length = Math.ceil((shortest + longest) / 2);
+				if (fits(`${prefix}${id.slice(0, length)}…${postfix}`)) shortest = length;
+				else longest = length - 1;
+			}
+
+			visibleLabel = `${prefix}${id.slice(0, shortest)}…${postfix}`;
+			if (!fits(visibleLabel)) {
+				visibleLabel = `${prefix.trimEnd()}…`;
+				if (!fits(visibleLabel)) {
+					visibleLabel = prefix.trimEnd();
+					if (!fits(visibleLabel)) visibleLabel = fits('…') ? '…' : '';
+				}
+			}
+		}
+
+		label.textContent = visibleLabel;
+		makeEl('title', {_dad:label}).textContent = id;
 	}
 
 	updateColor() {
@@ -556,6 +586,7 @@ export class VisualState extends SCXMLState {
 		const [,,w,h] = this.xywh;
 		const top = this.states.length>0 ? 15 : h/2;
 		setAttributes(this._vse.label, {x:w/2, y:top});
+		this.updateLabel();
 	}
 
 	containedWithin(s2) {

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -311,6 +311,55 @@ test('changing an initial attribute refreshes immediate child labels', () => {
 	}
 });
 
+test('state labels elide to fit and retain the complete ID in a tooltip', () => {
+	for (const children of [[], [{}]]) {
+		let width = 60;
+		const label = new FakeElement();
+		label.getComputedTextLength = () => Array.from(label.textContent).length * 10;
+		const state = Object.create(VisualState.prototype);
+		state._vse = {label};
+		state.states = children;
+		Object.defineProperties(state, {
+			id: {get: () => 'abcdefgh'},
+			isInitial: {get: () => false},
+			isParallelChild: {get: () => false},
+			isHistory: {get: () => false},
+			xywh: {get: () => [0, 0, width, 40]}
+		});
+
+		state.updateLabelPosition();
+		assert.equal(label.textContent, 'abc…');
+		assert.equal(label.children.at(-1).textContent, 'abcdefgh');
+		assert.equal(label.getAttribute('x'), '30');
+		assert.equal(label.getAttribute('y'), children.length ? '15' : '20');
+
+		width = 120;
+		state.updateLabelPosition();
+		assert.equal(label.textContent, 'abcdefgh');
+		assert.equal(label.children.at(-1).textContent, 'abcdefgh');
+	}
+});
+
+test('state label adornments also stay within the available width', () => {
+	const label = new FakeElement();
+	label.getComputedTextLength = () => Array.from(label.textContent).length * 10;
+	const state = Object.create(VisualState.prototype);
+	state._vse = {label};
+	state.states = [];
+	Object.defineProperties(state, {
+		id: {get: () => 'longHistoryState'},
+		isInitial: {get: () => true},
+		isParallelChild: {get: () => false},
+		isHistory: {get: () => true},
+		isDeep: {get: () => true},
+		xywh: {get: () => [0, 0, 30, 20]}
+	});
+
+	state.updateLabel();
+	assert.ok(label.getComputedTextLength() <= 10);
+	assert.equal(label.children.at(-1).textContent, 'longHistoryState');
+});
+
 test('deleting a selection clears it before removing graphics', () => {
 	for (const [command, expectedDeleteArgs] of [
 		['deleteSelectionOnly', [true]],

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -337,7 +337,6 @@ test('overflowing state labels are left-aligned and faded until they fit', () =>
 		assert.equal(label.children.at(-1).textContent, 'abcdefgh');
 		assert.equal(label.getAttribute('x'), '10');
 		assert.equal(label.getAttribute('y'), children.length ? '15' : '20');
-		assert.equal(label.getAttribute('text-anchor'), 'start');
 		assert.match(label.getAttribute('mask'), /^url\(#state-label-mask-\d+\)$/);
 		assert.equal(state._vse.labelMask.getAttribute('width'), '40');
 		assert.equal(state._vse.labelMaskSolid.getAttribute('width'), '25');
@@ -347,7 +346,6 @@ test('overflowing state labels are left-aligned and faded until they fit', () =>
 		state.updateLabelPosition();
 		assert.equal(label.textContent, 'abcdefgh');
 		assert.equal(label.getAttribute('x'), '60');
-		assert.equal(label.getAttribute('text-anchor'), 'middle');
 		assert.equal(label.getAttribute('mask'), null);
 		assert.equal(state._vse.labelMask, undefined);
 
@@ -355,7 +353,6 @@ test('overflowing state labels are left-aligned and faded until they fit', () =>
 		state.updateLabel();
 		assert.equal(label.textContent, id);
 		assert.equal(label.getAttribute('x'), '10');
-		assert.equal(label.getAttribute('text-anchor'), 'start');
 		assert.match(label.getAttribute('mask'), /^url\(#state-label-mask-\d+\)$/);
 		assert.equal(label.children.at(-1).textContent, id);
 	}
@@ -378,7 +375,6 @@ test('minimum-width adorned labels fade inside the state', () => {
 
 	state.updateLabel();
 	assert.equal(label.getAttribute('x'), '10');
-	assert.equal(label.getAttribute('text-anchor'), 'start');
 	assert.equal(state._vse.labelMask.getAttribute('width'), '10');
 	assert.equal(state._vse.labelMaskSolid.getAttribute('width'), '0');
 	assert.equal(state._vse.labelMaskFade.getAttribute('width'), '10');
@@ -387,7 +383,9 @@ test('minimum-width adorned labels fade inside the state', () => {
 
 test('the editor provides the shared state-label fade gradient', () => {
 	const editorHTML = fs.readFileSync(new URL('../../resources/scxmleditor.html', import.meta.url), 'utf8');
+	const editorCSS = fs.readFileSync(new URL('../../resources/scxmleditor.css', import.meta.url), 'utf8');
 	assert.match(editorHTML, /<linearGradient id='state-label-fade'/);
+	assert.match(editorCSS, /\.state text\[mask\]\s*\{\s*text-anchor:start;/);
 });
 
 test('deleting a selection clears it before removing graphics', () => {

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -386,6 +386,7 @@ test('the editor provides the shared state-label fade gradient', () => {
 	const editorCSS = fs.readFileSync(new URL('../../resources/scxmleditor.css', import.meta.url), 'utf8');
 	assert.match(editorHTML, /<linearGradient id='state-label-fade'/);
 	assert.match(editorCSS, /\.state text\[mask\]\s*\{\s*text-anchor:start;/);
+	assert.match(editorCSS, /\.state\.parallel > text\s*\{\s*opacity:var\(--state-label-opacity, 1\) !important;/);
 });
 
 test('deleting a selection clears it before removing graphics', () => {

--- a/test/unit/empty-parallel-resize.test.mjs
+++ b/test/unit/empty-parallel-resize.test.mjs
@@ -24,6 +24,10 @@ class FakeElement {
 		return this.attributes.get(name) ?? null;
 	}
 
+	removeAttribute(name) {
+		this.attributes.delete(name);
+	}
+
 	setAttribute(name, value) {
 		this.attributes.set(name, String(value));
 		if (name.startsWith('data-')) {
@@ -311,40 +315,57 @@ test('changing an initial attribute refreshes immediate child labels', () => {
 	}
 });
 
-test('state labels elide to fit and retain the complete ID in a tooltip', () => {
+test('overflowing state labels are left-aligned and faded until they fit', () => {
 	for (const children of [[], [{}]]) {
 		let width = 60;
+		let id = 'abcdefgh';
 		const label = new FakeElement();
 		label.getComputedTextLength = () => Array.from(label.textContent).length * 10;
 		const state = Object.create(VisualState.prototype);
-		state._vse = {label};
+		state._vse = {label, main:new FakeElement()};
 		state.states = children;
 		Object.defineProperties(state, {
-			id: {get: () => 'abcdefgh'},
+			id: {get: () => id},
 			isInitial: {get: () => false},
 			isParallelChild: {get: () => false},
 			isHistory: {get: () => false},
 			xywh: {get: () => [0, 0, width, 40]}
 		});
 
-		state.updateLabelPosition();
-		assert.equal(label.textContent, 'abc…');
+		state.updateLabel();
+		assert.equal(label.textContent, 'abcdefgh');
 		assert.equal(label.children.at(-1).textContent, 'abcdefgh');
-		assert.equal(label.getAttribute('x'), '30');
+		assert.equal(label.getAttribute('x'), '10');
 		assert.equal(label.getAttribute('y'), children.length ? '15' : '20');
+		assert.equal(label.getAttribute('text-anchor'), 'start');
+		assert.match(label.getAttribute('mask'), /^url\(#state-label-mask-\d+\)$/);
+		assert.equal(state._vse.labelMask.getAttribute('width'), '40');
+		assert.equal(state._vse.labelMaskSolid.getAttribute('width'), '25');
+		assert.equal(state._vse.labelMaskFade.getAttribute('width'), '15');
 
 		width = 120;
 		state.updateLabelPosition();
 		assert.equal(label.textContent, 'abcdefgh');
-		assert.equal(label.children.at(-1).textContent, 'abcdefgh');
+		assert.equal(label.getAttribute('x'), '60');
+		assert.equal(label.getAttribute('text-anchor'), 'middle');
+		assert.equal(label.getAttribute('mask'), null);
+		assert.equal(state._vse.labelMask, undefined);
+
+		id = 'abcdefghijklmnop';
+		state.updateLabel();
+		assert.equal(label.textContent, id);
+		assert.equal(label.getAttribute('x'), '10');
+		assert.equal(label.getAttribute('text-anchor'), 'start');
+		assert.match(label.getAttribute('mask'), /^url\(#state-label-mask-\d+\)$/);
+		assert.equal(label.children.at(-1).textContent, id);
 	}
 });
 
-test('state label adornments also stay within the available width', () => {
+test('minimum-width adorned labels fade inside the state', () => {
 	const label = new FakeElement();
 	label.getComputedTextLength = () => Array.from(label.textContent).length * 10;
 	const state = Object.create(VisualState.prototype);
-	state._vse = {label};
+	state._vse = {label, main:new FakeElement()};
 	state.states = [];
 	Object.defineProperties(state, {
 		id: {get: () => 'longHistoryState'},
@@ -356,8 +377,17 @@ test('state label adornments also stay within the available width', () => {
 	});
 
 	state.updateLabel();
-	assert.ok(label.getComputedTextLength() <= 10);
+	assert.equal(label.getAttribute('x'), '10');
+	assert.equal(label.getAttribute('text-anchor'), 'start');
+	assert.equal(state._vse.labelMask.getAttribute('width'), '10');
+	assert.equal(state._vse.labelMaskSolid.getAttribute('width'), '0');
+	assert.equal(state._vse.labelMaskFade.getAttribute('width'), '10');
 	assert.equal(label.children.at(-1).textContent, 'longHistoryState');
+});
+
+test('the editor provides the shared state-label fade gradient', () => {
+	const editorHTML = fs.readFileSync(new URL('../../resources/scxmleditor.html', import.meta.url), 'utf8');
+	assert.match(editorHTML, /<linearGradient id='state-label-fade'/);
 });
 
 test('deleting a selection clears it before removing graphics', () => {


### PR DESCRIPTION
Fixes #55.

## What changed

- Measure the complete native SVG state label after label edits and while state dimensions change.
- Keep fitting labels centered and unmasked.
- When a label approaches the available width, left-align it inside the rounded-state padding and lazily apply a native SVG mask that fades its right edge.
- Reuse one shared gradient while keeping width-specific masks only on currently overflowing states; remove each mask as soon as its label fits again.
- Ensure the selected parallel wrapper’s own label still obeys the existing zoom-level state-label opacity.
- Preserve the complete rendered label in the SVG and expose the full, unmodified state ID through a native `<title>` tooltip.
- Cover leaf and parent labels, resize transitions in both directions, ID edits that introduce overflow, minimum-width initial/history adornments, mask geometry, and the shared gradient.

## Verification

- `npm test` (15 passing tests, plus compile, lint, and case-sensitive import checks)
- Rendered a focused SVG fixture in headless Chromium to verify centered fitting text and the left-aligned right-edge fade inside a transformed state group.
- Packaged `/tmp/visual-scxml-editor-issue-55-fade.vsix` and inspected the included gradient and mask implementation.